### PR TITLE
Add rolelock option to servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ basic.conf
 
 # ignore mac Desktop Services Stores
 .DS_Store
+
+# ignore scylla_data files
+scylla_data/*

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ basic.conf
 
 # Dev config (contains secrets)
 /config/dev.exs
+
+# ignore mac Desktop Services Stores
+.DS_Store

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,3 +31,11 @@ services:
         limits:
           cpus: "1.0"
           memory: 4000M
+  scylla:
+    image: scylladb/scylla:5.1
+    ports:
+      - "9042:9042"
+    restart: always
+    command: --smp 1 --memory 1G --overprovisioned 1 --developer-mode 1
+    volumes:
+      - ./scylla_data:/var/lib/scylla

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,11 +31,3 @@ services:
         limits:
           cpus: "1.0"
           memory: 4000M
-  scylla:
-    image: scylladb/scylla:5.1
-    ports:
-      - "9042:9042"
-    restart: always
-    command: --smp 1 --memory 1G --overprovisioned 1 --developer-mode 1
-    volumes:
-      - ./scylla_data:/var/lib/scylla

--- a/lib/octocon/role_locks.ex
+++ b/lib/octocon/role_locks.ex
@@ -1,0 +1,62 @@
+defmodule Octocon.RoleLocks do
+  @moduledoc """
+  The RoleLock context.
+  """
+
+  @region_specifier {:region, :nam}
+
+  import Ecto.Query, warn: false
+  alias Octocon.Repo
+  alias Octocon.RoleLocks.RoleLock
+
+  @doc """
+  Returns a list of **all** role lock entries.
+  Used by the RoleLockManager to hydrate the cache on startup.
+  """
+  def list_role_locks do
+    Repo.all_regional(RoleLock, @region_specifier)
+  end
+
+  @doc """
+  Gets the role lock for a specific guild.
+  Returns `nil` if none exists.
+  """
+  def get_role_lock(guild_id) do
+    Repo.one_regional(
+      from(r in RoleLock, where: r.guild_id == ^to_string(guild_id)),
+      @region_specifier
+    )
+  end
+
+  @doc """
+  Sets the role lock for a guild.
+
+  Enforces that there is exactly one lock per guild by deleting any existing lock
+  for this guild before inserting the new one.
+  """
+  def set_role_lock(attrs) do
+    guild_id = attrs[:guild_id]
+    delete_role_lock(guild_id)
+
+    %RoleLock{}
+    |> change_role_lock(attrs)
+    |> Repo.insert_regional(@region_specifier)
+  end
+
+  @doc """
+  Deletes the role lock for a specific guild ID.
+  """
+  def delete_role_lock(guild_id) when is_binary(guild_id) do
+    Repo.delete_regional(%RoleLock{guild_id: guild_id}, @region_specifier)
+    :ok
+  rescue
+    _ in Ecto.StaleEntryError -> :ok
+  end
+
+  @doc """
+  Builds a changeset based on the given `RoleLock` struct and `attrs`.
+  """
+  def change_role_lock(%RoleLock{} = role_lock, attrs \\ %{}) do
+    RoleLock.changeset(role_lock, attrs)
+  end
+end

--- a/lib/octocon/role_locks/role_lock.ex
+++ b/lib/octocon/role_locks/role_lock.ex
@@ -1,0 +1,28 @@
+defmodule Octocon.RoleLocks.RoleLock do
+  @moduledoc """
+  A role lock entry. This is used to lock the Octocon bot from proxying members without a given role
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:guild_id, :string, autogenerate: false}
+
+  schema "role_locks" do
+    field :guild_id, :string
+    field :role_id, :string
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the given `Octocon.RoleLocks.RoleLock` struct and `attrs` to change.
+  """
+  def changeset(role_lock, attrs) do
+    role_lock
+    |> cast(attrs, [:guild_id, :role_id])
+    |> validate_required([:guild_id, :role_id])
+    |> validate_format(:guild_id, ~r/^\d{17,22}$/)
+    |> validate_format(:role_id, ~r/^\d{17,22}$/)
+    |> unique_constraint(:guild_id)
+  end
+end

--- a/lib/octocon/role_locks/role_lock.ex
+++ b/lib/octocon/role_locks/role_lock.ex
@@ -8,7 +8,6 @@ defmodule Octocon.RoleLocks.RoleLock do
   @primary_key {:guild_id, :string, autogenerate: false}
 
   schema "role_locks" do
-    field :guild_id, :string
     field :role_id, :string
 
     timestamps()

--- a/lib/octocon/server_settings/server_settings_data.ex
+++ b/lib/octocon/server_settings/server_settings_data.ex
@@ -12,6 +12,7 @@ defmodule Octocon.ServerSettings.ServerSettingsData do
   @primary_key false
   embedded_schema do
     field :log_channel, :string
+    field :role_lock, :string
     field :force_system_tags, :boolean, default: false
 
     field :proxy_disabled_users, {:array, :string}, default: []
@@ -22,7 +23,7 @@ defmodule Octocon.ServerSettings.ServerSettingsData do
   """
   def changeset(data, attrs \\ %{}) do
     data
-    |> cast(attrs, [:log_channel, :force_system_tags, :proxy_disabled_users])
+    |> cast(attrs, [:log_channel, :role_lock, :force_system_tags, :proxy_disabled_users])
     |> validate_required([:force_system_tags])
   end
 end

--- a/lib/octocon_discord/commands/admin.ex
+++ b/lib/octocon_discord/commands/admin.ex
@@ -5,6 +5,7 @@ defmodule OctoconDiscord.Commands.Admin do
 
   alias OctoconDiscord.ServerSettingsManager
   alias OctoconDiscord.ChannelBlacklistManager
+  alias OctoconDiscord.RoleLockManager
 
   alias OctoconDiscord.Utils
 
@@ -185,43 +186,26 @@ defmodule OctoconDiscord.Commands.Admin do
   end
 
   def role_lock_set(%{guild_id: guild_id} = context, options, skip \\ false) do
-    callback = fn ->
+    ensure_permissions(context, fn ->
       role = Utils.get_command_option(options, "role")
 
-      case RoleLockManager.edit_settings(to_string(guild_id), %{
-             role_lock: to_string(role)
-           }) do
+      case RoleLockManager.set(to_string(guild_id), to_string(role)) do
         :ok ->
-          Utils.success_embed("Set <@&{role}> as this server's log channel.")
-
-        {:error, :not_found} ->
-          case ServerSettingsManager.create_settings(to_string(guild_id)) do
-            :ok ->
-              role_lock_set(context, options)
-
-            _ ->
-              Utils.error_embed("An error occurred while setting the locked role.")
-          end
+          Utils.success_embed("Set <@&#{role}> as this server's required proxy role.")
 
         _ ->
           Utils.error_embed("An error occurred while setting the locked role.")
       end
-    end
-
-    if skip do
-      callback.()
-    else
-      ensure_permissions(context, callback)
-    end
+    end)
   end
 
   def role_lock_remove(%{guild_id: guild_id} = context, _options) do
     ensure_permissions(context, fn ->
-      case RoleLockManager.edit_settings(to_string(guild_id), %{role_lock: nil}) do
+      case RoleLockManager.remove(to_string(guild_id)) do
         :ok ->
           Utils.success_embed("Removed the role lock for this server.")
 
-        {:error, :not_found} ->
+        {:error, :not_rolelocked} ->
           Utils.error_embed("This server has no role lock set.")
 
         _ ->
@@ -275,6 +259,7 @@ defmodule OctoconDiscord.Commands.Admin do
         settings ->
           log_channel = settings.log_channel
           force_system_tags = settings.force_system_tags
+          role_lock = RoleLockManager.get_lock(to_string(guild_id))
 
           [
             embeds: [
@@ -292,6 +277,15 @@ defmodule OctoconDiscord.Commands.Admin do
                       case log_channel do
                         nil -> "None"
                         channel -> "<##{channel}>"
+                      end,
+                    inline: true
+                  },
+                  %Nostrum.Struct.Embed.Field{
+                    name: "Role Lock",
+                    value:
+                      case role_lock do
+                         nil -> "None"
+                         role_id -> "<@&#{role_id}>"
                       end,
                     inline: true
                   }
@@ -386,6 +380,31 @@ defmodule OctoconDiscord.Commands.Admin do
           %{
             name: "remove",
             description: "Removes the log channel for this server.",
+            type: :sub_command
+          }
+        ]
+      },
+      %{
+        name: "role-lock",
+        description: "Manages the proxy role lock for this server.",
+        type: :sub_command_group,
+        options: [
+          %{
+            name: "set",
+            description: "Sets the role required to use the proxy.",
+            type: :sub_command,
+            options: [
+              %{
+                name: "role",
+                type: :role,
+                description: "The role to require.",
+                required: true
+              }
+            ]
+          },
+          %{
+            name: "remove",
+            description: "Removes the role lock requirement.",
             type: :sub_command
           }
         ]

--- a/lib/octocon_discord/commands/admin.ex
+++ b/lib/octocon_discord/commands/admin.ex
@@ -11,6 +11,7 @@ defmodule OctoconDiscord.Commands.Admin do
   @subcommands %{
     "channel-blacklist" => &__MODULE__.channel_blacklist/2,
     "log-channel" => &__MODULE__.log_channel/2,
+    "role-lock" => &__MODULE__.role_lock/2,
     "view-settings" => &__MODULE__.view_settings/2,
     "force-system-tags" => &__MODULE__.force_system_tags/2
   }
@@ -24,6 +25,11 @@ defmodule OctoconDiscord.Commands.Admin do
   @log_channel_subcommands %{
     "set" => &__MODULE__.log_channel_set/2,
     "remove" => &__MODULE__.log_channel_remove/2
+  }
+
+  @role_lock_subcommands %{
+    "set" => &__MODULE__.role_lock_set/2,
+    "remove" => &__MODULE__.role_lock_remove/2
   }
 
   @impl true
@@ -165,6 +171,61 @@ defmodule OctoconDiscord.Commands.Admin do
 
         _ ->
           Utils.error_embed("An error occurred while removing the log channel.")
+      end
+    end)
+  end
+
+  def role_lock(context, options) do
+    subcommand = hd(options)
+
+    @role_lock_subcommands[subcommand.name].(
+      context,
+      subcommand.options
+    )
+  end
+
+  def role_lock_set(%{guild_id: guild_id} = context, options, skip \\ false) do
+    callback = fn ->
+      role = Utils.get_command_option(options, "role")
+
+      case RoleLockManager.edit_settings(to_string(guild_id), %{
+             role_lock: to_string(role)
+           }) do
+        :ok ->
+          Utils.success_embed("Set <@&{role}> as this server's log channel.")
+
+        {:error, :not_found} ->
+          case ServerSettingsManager.create_settings(to_string(guild_id)) do
+            :ok ->
+              role_lock_set(context, options)
+
+            _ ->
+              Utils.error_embed("An error occurred while setting the locked role.")
+          end
+
+        _ ->
+          Utils.error_embed("An error occurred while setting the locked role.")
+      end
+    end
+
+    if skip do
+      callback.()
+    else
+      ensure_permissions(context, callback)
+    end
+  end
+
+  def role_lock_remove(%{guild_id: guild_id} = context, _options) do
+    ensure_permissions(context, fn ->
+      case RoleLockManager.edit_settings(to_string(guild_id), %{role_lock: nil}) do
+        :ok ->
+          Utils.success_embed("Removed the role lock for this server.")
+
+        {:error, :not_found} ->
+          Utils.error_embed("This server has no role lock set.")
+
+        _ ->
+          Utils.error_embed("An error occurred while removing the role lock.")
       end
     end)
   end

--- a/lib/octocon_discord/commands/proxy.ex
+++ b/lib/octocon_discord/commands/proxy.ex
@@ -504,7 +504,7 @@ defmodule OctoconDiscord.Proxy do
 
   # Helpers
 
-  # Returns true if NO lock is set, OR if a lock is set and the user HAS the role.
+  # Returns true if no lock is set, or if a lock is set and the user has the role.
   defp has_required_role?(guild_id, member) do
     case RoleLockManager.get_lock(guild_id) do
       nil ->

--- a/lib/octocon_discord/commands/proxy.ex
+++ b/lib/octocon_discord/commands/proxy.ex
@@ -12,6 +12,7 @@ defmodule OctoconDiscord.Proxy do
 
   alias OctoconDiscord.{
     ChannelBlacklistManager,
+    RoleLockManager,
     ProxyCache,
     ServerSettingsManager,
     Utils
@@ -63,50 +64,57 @@ defmodule OctoconDiscord.Proxy do
       {:ok, proxy_data} ->
         {channel_id, parent_id, thread_id} = check_thread(message)
 
-        # Fast path: if the channel is blacklisted, don't bother checking anything else
+        # Fast path 1: if the channel is blacklisted, don't bother checking anything else
         unless ChannelBlacklistManager.is_blacklisted?(
                  to_string(channel_id),
                  to_string(parent_id)
                ) do
-          webhook = OctoconDiscord.WebhookManager.get_webhook(channel_id)
+          # Fast path 2: Check Role Lock
+          # If a lock exists and the user does NOT have the role, stop here.
+          if has_required_role?(to_string(message.guild_id), message.member) do
+            webhook = OctoconDiscord.WebhookManager.get_webhook(channel_id)
 
-          if webhook == nil do
-            :no_proxy
-          else
-            settings_template = %Octocon.Accounts.ServerSettings{
-              guild_id: to_string(message.guild_id)
-            }
-
-            server_proxy_settings =
-              proxy_data.settings.server_settings
-              |> Map.get(to_string(message.guild_id), nil)
-              |> case do
-                nil ->
-                  settings_template
-
-                server_settings ->
-                  settings_template
-                  |> Map.merge(server_settings)
-              end
-
-            if server_proxy_settings.proxying_disabled do
+            if webhook == nil do
               :no_proxy
             else
-              server_settings = ServerSettingsManager.get_settings(message.guild_id)
+              settings_template = %Octocon.Accounts.ServerSettings{
+                guild_id: to_string(message.guild_id)
+              }
 
-              fun.(%{
-                message: message,
-                webhook: webhook,
-                proxy_data:
-                  proxy_data
-                  |> Map.put(
-                    :settings,
-                    Map.merge(proxy_data.settings, %{server_settings: server_proxy_settings})
-                  ),
-                thread_id: thread_id,
-                server_settings: server_settings
-              })
+              server_proxy_settings =
+                proxy_data.settings.server_settings
+                |> Map.get(to_string(message.guild_id), nil)
+                |> case do
+                  nil ->
+                    settings_template
+
+                  server_settings ->
+                    settings_template
+                    |> Map.merge(server_settings)
+                end
+
+              if server_proxy_settings.proxying_disabled do
+                :no_proxy
+              else
+                server_settings = ServerSettingsManager.get_settings(message.guild_id)
+
+                fun.(%{
+                  message: message,
+                  webhook: webhook,
+                  proxy_data:
+                    proxy_data
+                    |> Map.put(
+                      :settings,
+                      Map.merge(proxy_data.settings, %{server_settings: server_proxy_settings})
+                    ),
+                  thread_id: thread_id,
+                  server_settings: server_settings
+                })
+              end
             end
+          else
+            # Role lock active and user missing role
+            :no_proxy
           end
         end
     end
@@ -492,5 +500,27 @@ defmodule OctoconDiscord.Proxy do
         "[Reply to:](https://discord.com/channels/#{message.guild_id}/#{reply.channel_id}/#{reply.id}) #{truncated_content}",
       color: Utils.hex_to_int(color)
     }
+  end
+
+  # Helpers
+
+  # Returns true if NO lock is set, OR if a lock is set and the user HAS the role.
+  defp has_required_role?(guild_id, member) do
+    case RoleLockManager.get_lock(guild_id) do
+      nil ->
+        # No lock exists, so they are allowed
+        true
+
+      required_role_id ->
+        # Lock exists, check if user has it.
+        required_role_int = String.to_integer(required_role_id)
+
+        if member && member.roles do
+          required_role_int in member.roles
+        else
+          # If we can't read the member/roles, we default to blocking them for safety
+          false
+        end
+    end
   end
 end

--- a/lib/octocon_discord/components/help_handler.ex
+++ b/lib/octocon_discord/components/help_handler.ex
@@ -61,6 +61,7 @@ defmodule OctoconDiscord.Components.HelpHandler do
     admin_view_settings: Pages.CommandList.Admin.ViewSettings,
     admin_force_system_tags: Pages.CommandList.Admin.ForceSystemTags,
     admin_log_channel: Pages.CommandList.Admin.LogChannel,
+    admin_role_lock: Pages.CommandList.Admin.RoleLock,
     danger_root: Pages.CommandList.Danger,
     danger_wipe_alters: Pages.CommandList.Danger.WipeAlters,
     danger_delete_account: Pages.CommandList.Danger.DeleteAccount,

--- a/lib/octocon_discord/components/help_handler/pages/command_list/admin.ex
+++ b/lib/octocon_discord/components/help_handler/pages/command_list/admin.ex
@@ -18,6 +18,11 @@ defmodule OctoconDiscord.Components.HelpHandler.Pages.CommandList.Admin do
       nav_page: "admin_log_channel"
     },
     %{
+      name: "role-lock",
+      description: "Manages a role lock for this server",
+      nav_page: "admin_role_lock"
+    },
+    %{
       name: "force-system-tags",
       description: "Toggles whether system tags are forced on this server",
       nav_page: "admin_force_system_tags"

--- a/lib/octocon_discord/components/help_handler/pages/command_list/admin/log_channel.ex
+++ b/lib/octocon_discord/components/help_handler/pages/command_list/admin/log_channel.ex
@@ -20,7 +20,7 @@ defmodule OctoconDiscord.Components.HelpHandler.Pages.CommandList.Admin.LogChann
         Removes the log channel for this server.
         ### Usage
         ```
-        /admin log-channel remove
+        /admin channel-blacklist remove
         ```
         """
       }

--- a/lib/octocon_discord/components/help_handler/pages/command_list/admin/log_channel.ex
+++ b/lib/octocon_discord/components/help_handler/pages/command_list/admin/log_channel.ex
@@ -20,7 +20,7 @@ defmodule OctoconDiscord.Components.HelpHandler.Pages.CommandList.Admin.LogChann
         Removes the log channel for this server.
         ### Usage
         ```
-        /admin channel-blacklist remove
+        /admin log-channel remove
         ```
         """
       }

--- a/lib/octocon_discord/components/help_handler/pages/command_list/admin/role_lock.ex
+++ b/lib/octocon_discord/components/help_handler/pages/command_list/admin/role_lock.ex
@@ -1,0 +1,40 @@
+defmodule OctoconDiscord.Components.HelpHandler.Pages.CommandList.Admin.RoleLock do
+  use OctoconDiscord.Components.HelpHandler.Pages
+
+  def embeds do
+    [
+      %Embed{
+        title: "#{Emojis.folder()} `/admin role-lock`",
+        color: Utils.hex_to_int("#0FBEAA"),
+        description: """
+        The `/admin role-lock` command group manages this server's role lock. When set, only members with the specified role will be able to proxy messages
+        ## #{Emojis.slashcommand()} `/admin role-lock set`
+        Sets the role lock for this server.
+        ### Usage
+        ```
+        /admin role-lock set <role>
+        ```
+        ### Parameters
+        - `role`: The role to lock proxying to.
+        ## #{Emojis.slashcommand()} `/admin role-lock remove`
+        Removes the role lock for this server.
+        ### Usage
+        ```
+        /admin role-lock remove
+        ```
+        """
+      }
+    ]
+  end
+
+  def components(uid) do
+    [
+      %{
+        type: 1,
+        components: [
+          back_button("admin_root", uid)
+        ]
+      }
+    ]
+  end
+end

--- a/lib/octocon_discord/consumer.ex
+++ b/lib/octocon_discord/consumer.ex
@@ -52,12 +52,13 @@ defmodule OctoconDiscord.Consumer do
         Nosedrum.Storage.Dispatcher.queue_command(name, module)
       end)
 
+      Logger.info("Registering commands for scope: #{inspect(scope)}")
       case Nosedrum.Storage.Dispatcher.process_queue(scope) do
         {:ok, _} ->
           Logger.info("Registered all commands!")
 
         {:error, e} ->
-          Logger.error("Failed to register all commands: #{e}")
+          Logger.error("Failed to register all commands: #{inspect(e)}")
       end
     end
 

--- a/lib/octocon_discord/role_lock_manager.ex
+++ b/lib/octocon_discord/role_lock_manager.ex
@@ -1,0 +1,99 @@
+defmodule OctoconDiscord.RoleLockManager do
+  @doc """
+  Manages the role lock.
+  """
+  alias Octocon.RoleLocks
+  alias Octocon.RoleLocks.RoleLock
+  use GenServer
+  require Logger
+
+  @table :discord_role_locks
+
+  # Client
+
+  @doc false
+  def start_link(_init_arg) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  Sets a role as the role lock for a guild.
+  If a lock already exists, it replaces the old one.
+  """
+  def set(guild_id, role_id) when is_binary(guild_id) and is_binary(role_id) do
+    # We simply overwrite the ETS entry.
+    # This satisfies "delete the old one and replace it with the new one" for the cache.
+    :ets.insert(@table, {guild_id, role_id})
+
+    # Assuming set_role_lock handles the DB transaction (upsert or delete+insert)
+    # to enforce the unique constraint on guild_id.
+    RoleLocks.set_role_lock(%{guild_id: guild_id, role_id: role_id})
+
+    :ok
+  end
+
+  @doc """
+  Unsets the role lock for a guild.
+  """
+  def remove(guild_id) when is_binary(guild_id) do
+    case :ets.lookup(@table, guild_id) do
+      [] ->
+        {:error, :not_rolelocked}
+
+      [{^guild_id, _role_id}] ->
+        :ets.delete(@table, guild_id)
+        RoleLocks.delete_role_lock(guild_id)
+        :ok
+    end
+  end
+
+  @doc """
+  Gets the role lock ID for a guild, if one exists.
+  Returns `nil` if no lock is set.
+  """
+  def get_lock(guild_id) when is_binary(guild_id) do
+    case :ets.lookup(@table, guild_id) do
+      [{^guild_id, role_id}] -> role_id
+      [] -> nil
+    end
+  end
+
+  # Server
+
+  @doc false
+  @impl true
+  def init([]) do
+    :ets.new(@table, [
+      :set,
+      :named_table,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true,
+      decentralized_counters: true
+    ])
+
+    {:ok, [], {:continue, :load_role_locks}}
+  end
+
+  @impl true
+  def handle_continue(:load_role_locks, state) do
+    # TODO: Replace this with actual waiting if necessary
+    Process.sleep(:timer.seconds(5))
+
+    locks = RoleLocks.list_role_locks()
+
+    # We map the DB results to {guild_id, role_id} tuples for ETS
+    :ets.insert(
+      @table,
+      locks
+      |> Enum.map(fn %{guild_id: gid, role_id: rid} -> {gid, rid} end)
+    )
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+end

--- a/lib/octocon_discord/supervisor.ex
+++ b/lib/octocon_discord/supervisor.ex
@@ -42,6 +42,7 @@ defmodule OctoconDiscord.Supervisor do
       # Custom ETS-backed persistent caches
       OctoconDiscord.ProxyCache,
       OctoconDiscord.ChannelBlacklistManager,
+      OctoconDiscord.RoleLockManager,
       # Gateway events
       Supervisor.child_spec({Task, fn -> start_unique_consumer() end}, id: :start_unique_consumer),
       # Component handlers

--- a/priv/old_repo/migrations/20260112064100_create_role_locks.exs
+++ b/priv/old_repo/migrations/20260112064100_create_role_locks.exs
@@ -1,0 +1,12 @@
+defmodule Octocon.Repo.Migrations.CreateRoleLocks do
+  use Ecto.Migration
+
+  def change do
+    create table(:role_locks, primary_key: false) do
+      add :guild_id, :string, primary_key: true
+      add :role_id, :string, null: false
+
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
This creates two new commands:
/admin role-lock set <role>
/admin role-lock remove 

This allows a server to lock proxying via Octocon behind a role of the admin's choice.  

Fixes OctoconDev/issues#470, Fixes OctoconDev/issues#471